### PR TITLE
fix(api_auth.signature): always use en_US locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - 3.4
   - 3.5
+  - 3.6
+  - 3.7
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 3.3
   - 3.4
   - 3.5
 

--- a/mifiel/api_auth/context_manager.py
+++ b/mifiel/api_auth/context_manager.py
@@ -1,0 +1,16 @@
+import locale
+import threading
+
+from contextlib import contextmanager
+
+LOCALE_LOCK = threading.Lock()
+
+
+@contextmanager
+def setlocale(name):
+    with LOCALE_LOCK:
+        saved = locale.setlocale(locale.LC_ALL)
+        try:
+            yield locale.setlocale(locale.LC_ALL, name)
+        finally:
+            locale.setlocale(locale.LC_ALL, saved)

--- a/mifiel/api_auth/signature.py
+++ b/mifiel/api_auth/signature.py
@@ -2,6 +2,7 @@ import hmac
 import base64
 import hashlib
 import datetime
+from context_manager import setlocale
 try:
   from urllib.parse import urlparse
 except:
@@ -36,7 +37,8 @@ class Signature:
     self.httpdate = httpdate
     if not self.httpdate:
       now = datetime.datetime.utcnow()
-      self.httpdate = now.strftime('%a, %d %b %Y %H:%M:%S GMT')
+      with setlocale('en_US.UTF-8'):
+        self.httpdate = now.strftime('%a, %d %b %Y %H:%M:%S GMT')
 
     url = urlparse(url)
     path = url.path

--- a/mifiel/api_auth/signature.py
+++ b/mifiel/api_auth/signature.py
@@ -2,7 +2,9 @@ import hmac
 import base64
 import hashlib
 import datetime
-from context_manager import setlocale
+
+from mifiel.api_auth.context_manager import setlocale
+
 try:
   from urllib.parse import urlparse
 except:


### PR DESCRIPTION
This fixes the problem of encoding in ascii the canonical_String when the locale of the system is different than `en_US`