### PR TITLE
Feat/add timeout parameter to client

### DIFF
--- a/mifiel/base.py
+++ b/mifiel/base.py
@@ -26,24 +26,32 @@ class Base(object):
     if not url:
       url = self.url()
 
+    kwargs = dict(
+      url=url,
+      auth=self.client.auth,
+      json=json,
+    )
+    if self.client.timeout:
+      kwargs.update({
+        'timeout': self.client.timeout
+      })
+
     if method == 'post':
-      response = requests.post(
-        url=url,
-        auth=self.client.auth,
-        data=data,
-        json=json,
-        files=files
-      )
+      kwargs.update({
+        'data': data,
+        'files': files
+      })
+      response = requests.post(**kwargs)
       if files:
         for file_name in files:
           file = files[file_name]
           if file: file[1].close()
     elif method == 'put':
-      response = requests.put(url, auth=self.client.auth, json=data)
+      response = requests.put(**kwargs)
     elif method == 'get':
-      response = requests.get(url, auth=self.client.auth, json=data)
+      response = requests.get(**kwargs)
     elif method == 'delete':
-      response = requests.delete(url, auth=self.client.auth, json=data)
+      response = requests.delete(**kwargs)
 
     return response
 

--- a/mifiel/client.py
+++ b/mifiel/client.py
@@ -5,6 +5,7 @@ class Client:
     self.sandbox = False
     self.auth = RequestsApiAuth(app_id, secret_key)
     self.base_url = 'https://www.mifiel.com'
+    self.timeout = None
 
   def use_sandbox(self):
     self.sandbox = True
@@ -15,3 +16,7 @@ class Client:
 
   def url(self):
     return self.base_url + '/api/v1/{path}'
+
+  def set_timeout(self, timeout):
+    assert type(timeout) == int
+    self.timeout = timeout

--- a/test/mifiellib/test_client.py
+++ b/test/mifiellib/test_client.py
@@ -15,3 +15,7 @@ class TestClient(BaseMifielCase):
   def test_base_url(self):
     self.client.set_base_url('http://example.com')
     self.assertRegex(self.client.url(), 'example.com')
+
+  def test_timeout(self):
+    self.client.set_timeout(timeout=4)
+    self.assertEqual(self.client.timeout, 4)

--- a/test/mifiellib/test_document.py
+++ b/test/mifiellib/test_document.py
@@ -133,6 +133,23 @@ class TestDocument(BaseMifielCase):
     assert req.headers['Authorization'] is not None
 
   @responses.activate
+  def test_create_with_timeout(self):
+    self.client.set_timeout(timeout=2)
+    doc_id = 'some-doc-id'
+    url = self.client.url().format(path='documents')
+    self.mock_doc_response(responses.POST, url, doc_id)
+
+    signatories = [{'email': 'some@email.com'}]
+    doc = Document.create(self.client, signatories, dhash='some-sha256-hash', name='some.pdf')
+
+    req = self.get_last_request()
+    self.assertEqual(req.method, 'POST')
+    self.assertEqual(req.url, url)
+    self.assertEqual(doc.id, doc_id)
+    self.assertEqual(doc.callback_url, 'some')
+    assert req.headers['Authorization'] is not None
+
+  @responses.activate
   def test_create_with_file(self):
     doc_id = 'some-doc-id'
     url = self.client.url().format(path='documents')


### PR DESCRIPTION
This pull requests add the ability to use the timeout parameter of the requests library so that the request timeout can be configured on the mifiel client.