### PR TITLE
Fix funtion to write pdf, pdf need work with binary

### DIFF
--- a/mifiel/document.py
+++ b/mifiel/document.py
@@ -100,17 +100,17 @@ class Document(Base):
   def save_file(self, path):
     url_ = self.url('{}/file').format(self.id)
     response = requests.get(url_, auth=self.client.auth)
-    with open(path, 'w') as file_:
-      file_.write(response.text)
+    with open(path, 'wb') as file_:
+      file_.write(response.content)
 
   def save_file_signed(self, path):
     url_ = self.url('{}/file_signed').format(self.id)
     response = requests.get(url_, auth=self.client.auth)
-    with open(path, 'w') as file_:
-      file_.write(response.text)
+    with open(path, 'wb') as file_:
+      file_.write(response.content)
 
   def save_xml(self, path):
     url_ = self.url('{}/xml').format(self.id)
     response = requests.get(url_, auth=self.client.auth)
-    with open(path, 'w') as file_:
-      file_.write(response.text)
+    with open(path, 'wb') as file_:
+      file_.write(response.content)


### PR DESCRIPTION
current function `save_file_signed` write pdf with blank pages in python 3. pdf files need work with binary instead string