### PR TITLE
Fix: serialize allowed_signature_methods correctly as JSON array

### DIFF
--- a/mifiel/document.py
+++ b/mifiel/document.py
@@ -50,11 +50,10 @@ class Document(Base):
 
     if 'viewers' in data:
       viewers = data.pop('viewers')
-      for index, item in enumerate(viewers):
-        for key, val in item.items():
-          data.update(
-            {'viewers[' + str(index) + '][' + str(key) + ']': val}
-          )
+      for index, item in enumerate(signatories):
+      for key, val in item.items():
+        value = json.dumps(val) if key == 'allowed_signature_methods' and isinstance(val, list) else val
+        data[f'signatories[{index}][{key}]'] = value
 
     if 'callback_url' in kwargs: data['callback_url'] = kwargs.get('callback_url')
     if file:

--- a/mifiel/document.py
+++ b/mifiel/document.py
@@ -46,9 +46,13 @@ class Document(Base):
       for key, val in item.items():
         if key == 'allowed_signature_methods' and isinstance(val, list):
           for method in val:
-            data[f'signatories[{index}][{key}][]'] = method
+            data.append(
+              (f'signatories[{index}][{key}][]', method)
+            )
         else:
-            data[f'signatories[{index}][{key}]'] = val
+            data.append(
+              (f'signatories[{index}][{key}]', val)
+            )
 
     if 'viewers' in data:
       viewers = data.pop('viewers')

--- a/mifiel/document.py
+++ b/mifiel/document.py
@@ -42,17 +42,16 @@ class Document(Base):
       raise ValueError('A name is required when using hash')
 
     data = kwargs.copy()
+    signatory_array_fields = []
     for index, item in enumerate(signatories):
       for key, val in item.items():
         if key == 'allowed_signature_methods' and isinstance(val, list):
           for method in val:
-            data.append(
+            signatory_array_fields.append(
               (f'signatories[{index}][{key}][]', method)
             )
         else:
-            data.append(
-              (f'signatories[{index}][{key}]', val)
-            )
+          data[f'signatories[{index}][{key}]'] = val
 
     if 'viewers' in data:
       viewers = data.pop('viewers')
@@ -62,13 +61,18 @@ class Document(Base):
             {'viewers[' + str(index) + '][' + str(key) + ']': val}
           )
 
-    if 'callback_url' in kwargs: data['callback_url'] = kwargs.get('callback_url')
+    if 'callback_url' in kwargs:
+      data['callback_url'] = kwargs.get('callback_url')
+    if dhash:
+      data['original_hash'] = data.pop('dhash')
+
+    if signatory_array_fields:
+      data = list(data.items()) + signatory_array_fields
+
     if file:
       mimetype = mimetypes.guess_type(file)[0]
       _file = open(file, 'rb')
       file = {'file': (basename(_file.name), _file, mimetype)}
-    if dhash:
-      data['original_hash'] = data.pop('dhash')
 
     doc = Document(client)
     doc.process_request('post', data=data, files=file)

--- a/mifiel/document.py
+++ b/mifiel/document.py
@@ -44,16 +44,19 @@ class Document(Base):
     data = kwargs.copy()
     for index, item in enumerate(signatories):
       for key, val in item.items():
-        data.update(
-          {'signatories[' + str(index) + '][' + str(key) + ']': val}
-        )
+        if key == 'allowed_signature_methods' and isinstance(val, list):
+          for method in val:
+            data[f'signatories[{index}][{key}][]'] = method
+        else:
+            data[f'signatories[{index}][{key}]'] = val
 
     if 'viewers' in data:
       viewers = data.pop('viewers')
-      for index, item in enumerate(signatories):
-      for key, val in item.items():
-        value = json.dumps(val) if key == 'allowed_signature_methods' and isinstance(val, list) else val
-        data[f'signatories[{index}][{key}]'] = value
+      for index, item in enumerate(viewers):
+        for key, val in item.items():
+          data.update(
+            {'viewers[' + str(index) + '][' + str(key) + ']': val}
+          )
 
     if 'callback_url' in kwargs: data['callback_url'] = kwargs.get('callback_url')
     if file:


### PR DESCRIPTION
This PR fixes an issue where the SDK was incorrectly sending `allowed_signature_methods` as a Python string instead of a JSON array, causing a 500 Internal Server Error when using mixed signature types like `FEA` and `FESCV`.

### What’s changed
- In the `Document.create()` method, the `allowed_signature_methods` field is now properly serialized using `json.dumps()` before being sent in the form data.

### Why
The Mifiel API expects `allowed_signature_methods` to be a JSON array (e.g. `["FEA"]`), not a Python string like `"['FEA']"` or `"FEA,FESCV"`. The previous version of the SDK unintentionally broke this compatibility when posting multipart/form-data requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of signatory field data formatting in document creation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->