### PR TITLE
fix(document): repair Document.create after signatory serialization change

### DIFF
--- a/mifiel/document.py
+++ b/mifiel/document.py
@@ -50,11 +50,10 @@ class Document(Base):
 
     if 'viewers' in data:
       viewers = data.pop('viewers')
-      for index, item in enumerate(viewers):
-        for key, val in item.items():
-          data.update(
-            {'viewers[' + str(index) + '][' + str(key) + ']': val}
-          )
+      for index, item in enumerate(signatories):
+      for key, val in item.items():
+        value = json.dumps(val) if key == 'allowed_signature_methods' and isinstance(val, list) else val
+        data[f'signatories[{index}][{key}]'] = value
 
     if 'callback_url' in kwargs: data['callback_url'] = kwargs.get('callback_url')
     if file:

--- a/mifiel/document.py
+++ b/mifiel/document.py
@@ -46,9 +46,13 @@ class Document(Base):
       for key, val in item.items():
         if key == 'allowed_signature_methods' and isinstance(val, list):
           for method in val:
-            data[f'signatories[{index}][{key}][]'] = method
+            data.append(
+              (f'signatories[{index}][{key}][]', method)
+            )
         else:
-            data[f'signatories[{index}][{key}]'] = val
+            data.append(
+              (f'signatories[{index}][{key}]', val)
+            )
 
     if 'viewers' in data:
       viewers = data.pop('viewers')

--- a/mifiel/document.py
+++ b/mifiel/document.py
@@ -42,17 +42,16 @@ class Document(Base):
       raise ValueError('A name is required when using hash')
 
     data = kwargs.copy()
+    signatory_array_fields = []
     for index, item in enumerate(signatories):
       for key, val in item.items():
         if key == 'allowed_signature_methods' and isinstance(val, list):
           for method in val:
-            data.append(
+            signatory_array_fields.append(
               (f'signatories[{index}][{key}][]', method)
             )
         else:
-            data.append(
-              (f'signatories[{index}][{key}]', val)
-            )
+          data[f'signatories[{index}][{key}]'] = val
 
     if 'viewers' in data:
       viewers = data.pop('viewers')
@@ -62,13 +61,18 @@ class Document(Base):
             {'viewers[' + str(index) + '][' + str(key) + ']': val}
           )
 
-    if 'callback_url' in kwargs: data['callback_url'] = kwargs.get('callback_url')
+    if 'callback_url' in kwargs:
+      data['callback_url'] = kwargs.get('callback_url')
+    if dhash:
+      data['original_hash'] = data.pop('dhash')
+
+    if signatory_array_fields:
+      data = list(data.items()) + signatory_array_fields
+
     if file:
       mimetype = mimetypes.guess_type(file)[0]
       _file = open(file, 'rb')
       file = {'file': (basename(_file.name), _file, mimetype)}
-    if dhash:
-      data['original_hash'] = data.pop('dhash')
 
     doc = Document(client)
     doc.process_request('post', data=data, files=file)

--- a/mifiel/document.py
+++ b/mifiel/document.py
@@ -44,16 +44,19 @@ class Document(Base):
     data = kwargs.copy()
     for index, item in enumerate(signatories):
       for key, val in item.items():
-        data.update(
-          {'signatories[' + str(index) + '][' + str(key) + ']': val}
-        )
+        if key == 'allowed_signature_methods' and isinstance(val, list):
+          for method in val:
+            data[f'signatories[{index}][{key}][]'] = method
+        else:
+            data[f'signatories[{index}][{key}]'] = val
 
     if 'viewers' in data:
       viewers = data.pop('viewers')
-      for index, item in enumerate(signatories):
-      for key, val in item.items():
-        value = json.dumps(val) if key == 'allowed_signature_methods' and isinstance(val, list) else val
-        data[f'signatories[{index}][{key}]'] = value
+      for index, item in enumerate(viewers):
+        for key, val in item.items():
+          data.update(
+            {'viewers[' + str(index) + '][' + str(key) + ']': val}
+          )
 
     if 'callback_url' in kwargs: data['callback_url'] = kwargs.get('callback_url')
     if file:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`Document.create` was calling `data.append(...)` while `data` was still a `dict`, which raised `AttributeError` and broke every create path (hash-only, file upload, timeout).

## Changes

- Keep scalar signatory fields on the `data` dict (`signatories[i][key]`).
- Collect `allowed_signature_methods` list values as repeated `signatories[i][allowed_signature_methods][]` entries.
- After handling `viewers`, `callback_url`, and `original_hash` (from `dhash`), convert `data` to a list of tuples plus the array-field tuples when needed so `requests` sends duplicate field names correctly for multipart form posts.

## Testing

`poetry run pytest` — all 30 tests pass.

This branch is intended to be merged into `fix/serialize-allowed-signature-methods` so [PR #15](https://github.com/Mifiel/python-api-client/pull/15) can pass CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f62b6f2-0136-401f-98ee-f2238c14771e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f62b6f2-0136-401f-98ee-f2238c14771e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

